### PR TITLE
feat: add CloseOptions to client close

### DIFF
--- a/packages/exchange/src/browser/BrowserWsHost.ts
+++ b/packages/exchange/src/browser/BrowserWsHost.ts
@@ -3,9 +3,10 @@ import chalk from 'chalk'
 import { Server, WebSocket } from 'mock-socket'
 import { URL } from 'url'
 import { v4 as uuid } from 'uuid'
-import { BaseHost, CloseOptions, HostOptions, getCloseOptions } from '../ws/Host'
+import { BaseHost, CloseOptions, Host, HostOptions, getCloseOptions } from '../ws/Host'
 import { logger } from '../logger'
 import { ConnectionId, Connection } from '../types'
+import { getBrowserCloseEvent } from './browserCloseEvent'
 
 export type BrowserWsHostOptions = Partial<HostOptions> & {
     url: URL
@@ -22,7 +23,7 @@ export const MockedSocket = function (url: string | URL, protocols?: string | st
  *  - bundling within browsers such as for Storybook
  *  - browser hosted tests such as Cypress
  */
-export class BrowserWsHost extends BaseHost {
+export class BrowserWsHost extends BaseHost implements Host {
     private options: BrowserWsHostOptions
     public readonly WebSocket = MockedSocket
     private server: Server
@@ -62,7 +63,7 @@ export class BrowserWsHost extends BaseHost {
             const connection: Connection = {
                 id: connectionId,
                 url: this.options.url,
-                close: ({ code, reason }) => client.close({ code, reason, wasClean: true }),
+                close: options => client.close(getBrowserCloseEvent(options)),
                 write: (raw: string | Buffer) => {
                     logger(chalk.red('←'), `${raw}`)
                     client.send(raw)

--- a/packages/exchange/src/browser/InlineFakeHost.ts
+++ b/packages/exchange/src/browser/InlineFakeHost.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { Client, Server, WebSocket as MockedSocket } from 'mock-socket'
 import { URL } from 'url'
 import { ProtocolHandler } from '../deprecated/ProtocolHandler'
-import { BaseFakeHost, HostOptions } from '../deprecated/BaseFakeHost'
+import { BaseFakeHost, CloseOptions, HostOptions } from '../deprecated/BaseFakeHost'
 import { Connection, ConnectionId } from '../types'
 import { enableLogger, logger } from '../logger'
 
@@ -43,8 +43,17 @@ export class InlineFakeHost extends BaseFakeHost {
         return await Promise.resolve()
     }
 
-    disconnect() {
-        this.client?.close()
+    disconnect(options?: Partial<CloseOptions>) {
+        this.client?.close(
+            options
+                ? {
+                      code: 1000,
+                      reason: '',
+                      wasClean: true,
+                      ...options,
+                  }
+                : undefined,
+        )
     }
 
     start() {
@@ -62,7 +71,7 @@ export class InlineFakeHost extends BaseFakeHost {
             this.connection = {
                 id: connectionId,
                 url: this.getUrl(client.url),
-                close: client.close,
+                close: ({ code, reason }) => client.close({ code, reason, wasClean: true }),
                 write: (raw: string | Buffer) => client.send(raw),
             }
 

--- a/packages/exchange/src/browser/InlineFakeHost.ts
+++ b/packages/exchange/src/browser/InlineFakeHost.ts
@@ -5,6 +5,7 @@ import { ProtocolHandler } from '../deprecated/ProtocolHandler'
 import { BaseFakeHost, CloseOptions, HostOptions } from '../deprecated/BaseFakeHost'
 import { Connection, ConnectionId } from '../types'
 import { enableLogger, logger } from '../logger'
+import { getBrowserCloseEvent } from './browserCloseEvent'
 
 /**
  * @deprecated The method is deprecated and will be removed in the next major version.
@@ -71,7 +72,7 @@ export class InlineFakeHost extends BaseFakeHost {
             this.connection = {
                 id: connectionId,
                 url: this.getUrl(client.url),
-                close: ({ code, reason }) => client.close({ code, reason, wasClean: true }),
+                close: options => getBrowserCloseEvent(options),
                 write: (raw: string | Buffer) => client.send(raw),
             }
 

--- a/packages/exchange/src/browser/browserCloseEvent.ts
+++ b/packages/exchange/src/browser/browserCloseEvent.ts
@@ -1,0 +1,13 @@
+import { CloseConnectionOptions } from '../types'
+
+const CLOSE_NORMAL = 1000
+const CLOSE_NO_STATUS = 1005
+
+export const getBrowserCloseEvent = (options?: CloseConnectionOptions) => {
+    if (options) {
+        // `wasClean` is specific for mock-socket
+        // See: https://github.com/thoov/mock-socket/blob/b08f4ca018a0e0ce672af71cf9cf6c56cfcd9977/src/event/factory.js#L58
+        return { ...options, wasClean: [CLOSE_NORMAL, CLOSE_NO_STATUS].includes(options.code) }
+    }
+    return options
+}

--- a/packages/exchange/src/deprecated/BaseFakeHost.ts
+++ b/packages/exchange/src/deprecated/BaseFakeHost.ts
@@ -6,6 +6,11 @@ export interface HostOptions {
     debug?: boolean
 }
 
+export interface CloseOptions {
+    code: number
+    reason: string
+}
+
 /**
  * @deprecated The method is deprecated and will be removed in the next major version.
  * See https://ilikejames.github.io/fakehost/#/migrating-from-v0-to-v1 for more information.
@@ -13,7 +18,7 @@ export interface HostOptions {
 export interface FakeHost {
     readonly url: Promise<string>
     dispose: () => Promise<void>
-    disconnect: () => void
+    disconnect: (options?: Partial<CloseOptions>) => void
     getConnections: () => Connection[]
     start: (port?: number) => void
     refuseNewConnections: boolean
@@ -53,7 +58,7 @@ export abstract class BaseFakeHost implements FakeHost {
         })
     }
 
-    abstract disconnect(): void
+    abstract disconnect(options?: Partial<CloseOptions>): void
 
     abstract start(): void
 

--- a/packages/exchange/src/deprecated/SockJsFakeHost.ts
+++ b/packages/exchange/src/deprecated/SockJsFakeHost.ts
@@ -4,7 +4,7 @@ import { AddressInfo } from 'net'
 import sockjs, { Connection as InboundConnection, Server } from 'sockjs'
 import { URL } from 'url'
 import { ProtocolHandler } from './ProtocolHandler'
-import { BaseFakeHost, HostOptions } from './BaseFakeHost'
+import { BaseFakeHost, CloseOptions, HostOptions } from './BaseFakeHost'
 import { enableLogger, logger } from '../logger'
 import { Connection, ConnectionId } from '../types'
 
@@ -108,9 +108,9 @@ export class SockJsFakeHost extends BaseFakeHost {
         })
     }
 
-    disconnect() {
+    disconnect(closeOptions?: CloseOptions) {
         this.connections.forEach((connection: InboundConnection) => {
-            connection.close()
+            connection.close(closeOptions?.code.toString(), closeOptions?.reason)
             connection.destroy()
         })
     }

--- a/packages/exchange/src/deprecated/WsFakeHost.ts
+++ b/packages/exchange/src/deprecated/WsFakeHost.ts
@@ -4,7 +4,7 @@ import { URL } from 'url'
 import WebSocket from 'ws'
 import { v4 as uuid } from 'uuid'
 import { ProtocolHandler } from './ProtocolHandler'
-import { BaseFakeHost, HostOptions } from './BaseFakeHost'
+import { BaseFakeHost, CloseOptions, HostOptions } from './BaseFakeHost'
 import { enableLogger, logger } from '../logger'
 import { Connection, ConnectionId } from '../types'
 
@@ -111,10 +111,10 @@ export class WsFakeHost extends BaseFakeHost {
         })
     }
 
-    disconnect() {
+    disconnect(closeOptions?: CloseOptions) {
         logger(chalk.yellow(`${this.options.name}: Disconnecting clients.`))
         this.connections.forEach(connection => {
-            connection.close()
+            connection.close(closeOptions?.code, closeOptions?.reason)
         })
     }
 }

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -1,4 +1,4 @@
-export type { Connection, ConnectionId, ExchangeEvent } from './types'
+export type { CloseConnectionOptions, Connection, ConnectionId, ExchangeEvent } from './types'
 export { enableLogger } from './logger'
 export * from './ws'
 export * from './deprecated'

--- a/packages/exchange/src/types.ts
+++ b/packages/exchange/src/types.ts
@@ -6,9 +6,10 @@ export type CloseConnectionOptions = {
     code: number
     reason: string
 }
+
 export interface Connection {
     url: URL
-    close: (options: CloseConnectionOptions) => void
+    close: (options?: CloseConnectionOptions) => void
     readonly id: ConnectionId
     write: (message: string | Buffer) => void
     isClosed?: boolean

--- a/packages/exchange/src/types.ts
+++ b/packages/exchange/src/types.ts
@@ -2,9 +2,13 @@ import { URL } from 'url'
 
 export type ConnectionId = string & { __connectionId: never }
 
+export type CloseConnectionOptions = {
+    code: number
+    reason: string
+}
 export interface Connection {
     url: URL
-    close: () => void
+    close: (options: CloseConnectionOptions) => void
     readonly id: ConnectionId
     write: (message: string | Buffer) => void
     isClosed?: boolean

--- a/packages/exchange/src/ws/Host.ts
+++ b/packages/exchange/src/ws/Host.ts
@@ -1,4 +1,4 @@
-import { Connection, ConnectionId, EventMap } from '../types'
+import { CloseConnectionOptions, Connection, ConnectionId, EventMap } from '../types'
 import { URL } from 'url'
 
 type HandlerMap = {
@@ -11,10 +11,8 @@ export type HostOptions = {
     silent: boolean
 }
 
-export type CloseOptions = {
+export type CloseOptions = CloseConnectionOptions & {
     path?: string
-    code: number
-    reason: string
 }
 
 export type Host = {
@@ -65,8 +63,9 @@ export abstract class BaseHost implements Host {
 
 const defaultCloseOptions: CloseOptions = {
     code: 1000,
-    reason: '',
+    reason: 'Service disconnected',
 }
+
 export function getCloseOptions(options?: Partial<CloseOptions>): CloseOptions {
     return {
         ...defaultCloseOptions,

--- a/packages/exchange/src/ws/Host.ts
+++ b/packages/exchange/src/ws/Host.ts
@@ -11,10 +11,16 @@ export type HostOptions = {
     silent: boolean
 }
 
+export type CloseOptions = {
+    path?: string
+    code: number
+    reason: string
+}
+
 export type Host = {
     on: <Key extends keyof EventMap>(e: Key, handler: (e: EventMap[Key]) => void) => void
     off: <Key extends keyof EventMap>(e: Key, handler: (e: EventMap[Key]) => void) => void
-    disconnect: (path?: string) => void
+    disconnect: (options?: Partial<CloseOptions>) => void
     dispose: () => Promise<void>
     get refuseNewConnections(): boolean
     set refuseNewConnections(refuse: boolean)
@@ -52,7 +58,18 @@ export abstract class BaseHost implements Host {
         this._refuseNewConnections = refuse
     }
 
-    abstract disconnect(): void
+    abstract disconnect(options?: Partial<CloseOptions>): void
     abstract dispose(): Promise<void>
     abstract get url(): Promise<URL>
+}
+
+const defaultCloseOptions: CloseOptions = {
+    code: 1000,
+    reason: '',
+}
+export function getCloseOptions(options?: Partial<CloseOptions>): CloseOptions {
+    return {
+        ...defaultCloseOptions,
+        ...options,
+    }
 }

--- a/packages/exchange/src/ws/WsHost.ts
+++ b/packages/exchange/src/ws/WsHost.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { URL } from 'url'
 import { v4 as uuid } from 'uuid'
 import { WebSocketServer, ServerOptions, Server } from 'ws'
-import { BaseHost, CloseOptions, HostOptions, getCloseOptions } from './Host'
+import { BaseHost, CloseOptions, Host, HostOptions, getCloseOptions } from './Host'
 import { logger } from '../logger'
 import { ConnectionId, Connection } from '../types'
 
@@ -23,7 +23,7 @@ export type WsHostOptions = WsStandaloneOptions | WsHostedOptions
  *  - command line
  *  - nodejs test frameworks such as jest, Playwright, etc.
  */
-export class WsHost extends BaseHost {
+export class WsHost extends BaseHost implements Host {
     private ws: WebSocketServer
     private options: Partial<WsHostOptions> = {}
     public readonly port: Promise<number>
@@ -79,8 +79,8 @@ export class WsHost extends BaseHost {
             const connection: Connection = {
                 id,
                 url: requestUrl,
-                close: ({ code, reason }) => {
-                    socket.close(code, reason)
+                close: options => {
+                    socket.close(options?.code, options?.reason)
                     this.connections.delete(connection.id)
                 },
                 write: (raw: string | Buffer) => {
@@ -110,7 +110,7 @@ export class WsHost extends BaseHost {
         })
     }
 
-    disconnect(options?: CloseOptions): void {
+    disconnect(options?: Partial<CloseOptions>): void {
         const { path, code, reason } = getCloseOptions(options)
         const connections =
             path && this.pathConnections.has(path)

--- a/packages/exchange/src/ws/integration.spec.ts
+++ b/packages/exchange/src/ws/integration.spec.ts
@@ -120,7 +120,7 @@ for (const host of hosts) {
 
                 closeEvents.forEach(evt => {
                     expect(evt.code).toEqual(1000)
-                    expect(evt.reason).toEqual('')
+                    expect(evt.reason).toEqual('Service disconnected')
                 })
             } finally {
                 await service.dispose()

--- a/packages/exchange/src/ws/integration.spec.ts
+++ b/packages/exchange/src/ws/integration.spec.ts
@@ -112,11 +112,47 @@ for (const host of hosts) {
                 expect(service.connectionCount).toBe(2)
 
                 service.disconnect()
-                await Promise.all([
-                    new Promise(resolve => client1.addEventListener('close', resolve)),
-                    new Promise(resolve => client2.addEventListener('close', resolve)),
+                const closeEvents = await Promise.all([
+                    new Promise<CloseEvent>(resolve => client1.addEventListener('close', resolve)),
+                    new Promise<CloseEvent>(resolve => client2.addEventListener('close', resolve)),
                 ])
                 expect(service.connectionCount).toBe(0)
+
+                closeEvents.forEach(evt => {
+                    expect(evt.code).toEqual(1000)
+                    expect(evt.reason).toEqual('')
+                })
+            } finally {
+                await service.dispose()
+            }
+        })
+
+        it('service disconnecting clients with a specific code', async () => {
+            const service = getService(host)
+            try {
+                expect(service.connectionCount).toBe(0)
+
+                const client1 = new globalThis.WebSocket(await service.url)
+                const client2 = new globalThis.WebSocket(await service.url)
+
+                await Promise.all([
+                    new Promise(resolve => client1.addEventListener('open', resolve)),
+                    new Promise(resolve => client2.addEventListener('open', resolve)),
+                ])
+                expect(service.connectionCount).toBe(2)
+
+                const closeOptions = { code: 4012, reason: 'Too many connections ' }
+                service.disconnect(closeOptions)
+                const closeEvents = await Promise.all([
+                    new Promise<CloseEvent>(resolve => client1.addEventListener('close', resolve)),
+                    new Promise<CloseEvent>(resolve => client2.addEventListener('close', resolve)),
+                ])
+                expect(service.connectionCount).toBe(0)
+
+                closeEvents.forEach(evt => {
+                    expect(evt.code).toEqual(closeOptions.code)
+                    expect(evt.reason).toEqual(closeOptions.reason)
+                })
             } finally {
                 await service.dispose()
             }

--- a/packages/signalr/fake-signalr/src/FakeSignalrHub.ts
+++ b/packages/signalr/fake-signalr/src/FakeSignalrHub.ts
@@ -1,6 +1,12 @@
 import { HubMessage, IStreamResult, Subject } from '@microsoft/signalr'
 import { MessagePackHubProtocol } from '@microsoft/signalr-protocol-msgpack'
-import { Connection, ConnectionId, Host, ExchangeEvent } from '@fakehost/exchange'
+import {
+    CloseConnectionOptions,
+    Connection,
+    ConnectionId,
+    Host,
+    ExchangeEvent,
+} from '@fakehost/exchange'
 import { Observable } from 'rxjs'
 import { ClientState } from './ClientState'
 import { MessageType, InboundMessage, isHandshakeMessage } from './messageTypes'
@@ -60,8 +66,8 @@ export class FakeSignalrHub<
         private format?: FormatTarget<Hub, Receiver>,
     ) {}
 
-    disconnect() {
-        this.host?.disconnect(this.path)
+    disconnect(options?: CloseConnectionOptions) {
+        this.host?.disconnect({ path: this.path, ...options })
     }
 
     setHost(host: Host) {
@@ -125,7 +131,7 @@ export class FakeSignalrHub<
 
         if (!isHandshakeMessage(parsed)) {
             console.error('Expected initial handshake message, but none was received.')
-            connection.close()
+            connection.close({ code: 1002, reason: 'No handshake supplied' })
             return
         }
 


### PR DESCRIPTION
I'd like to add a few tests on one of my applications where we need to show different errors based on the rejection reason coming from the server.

However, currently `@fakehost/exchange` doesn't have a way of providing these close reasons (I think the browser defaults it to code: 1000).

This PR adds in an option to `host.disconnect()` so that we can pass in any reason we might need.

If you need some additional changes, I'm happy to help :D